### PR TITLE
fix the msgraph member resource template to use the correct url value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.3.0
+Features:
+- Rename packages to `ms-terraform-lsp`
+
+Bug Fixes:
+- Fix the msgraph memeber resource template to use the correct url value.
+
 ## v0.2.0
 
 Features

--- a/internal/langserver/handlers/snippets/templates.go
+++ b/internal/langserver/handlers/snippets/templates.go
@@ -3,6 +3,7 @@ package snippets
 import (
 	"embed"
 	"encoding/json"
+	"strings"
 
 	lsp "github.com/Azure/ms-terraform-lsp/internal/protocol"
 	provider_schema "github.com/Azure/ms-terraform-lsp/provider-schema"
@@ -60,6 +61,7 @@ func MSGraphTemplateCandidates(editRange lsp.Range) []lsp.CompletionItem {
 		}
 		data, _ := json.Marshal(event)
 
+		newText := strings.ReplaceAll(template.TextEdit.NewText, "$ref", "\\$ref")
 		msgraphTemplateCandidates = append(msgraphTemplateCandidates, lsp.CompletionItem{
 			Label:  template.Label,
 			Kind:   lsp.SnippetCompletion,
@@ -73,7 +75,7 @@ func MSGraphTemplateCandidates(editRange lsp.Range) []lsp.CompletionItem {
 			InsertTextMode:   lsp.AdjustIndentation,
 			TextEdit: &lsp.TextEdit{
 				Range:   editRange,
-				NewText: template.TextEdit.NewText,
+				NewText: newText,
 			},
 			Command: &lsp.Command{
 				Title:     "",


### PR DESCRIPTION
Previously, the value of member resource template is 

```
  url = "groups/${"The id of the groups resource"}/members/"
```

, but it should be 

```
  url = "groups/${"The id of the groups resource"}/members/$ref"
```
