### PR TITLE
Add `deprecated` variable in module schema

### DIFF
--- a/module-schema/schema/core_schema.go
+++ b/module-schema/schema/core_schema.go
@@ -18,6 +18,7 @@ const (
 	sensitive   = "sensitive"
 	validation  = "validation"
 	ephemeral   = "ephemeral"
+	deprecated  = "deprecated"
 )
 
 func FromHCLFile(fileName string) (*SchemaBlock, error) {
@@ -65,6 +66,7 @@ func FromHCLBody(body hcl.Body) (map[string]*SchemaAttribute, error) {
 				{Name: hclDefault},
 				{Name: sensitive},
 				{Name: ephemeral},
+				{Name: deprecated},
 			},
 			Blocks: []hcl.BlockHeaderSchema{
 				{Type: validation},

--- a/module-schema/schema/core_schema_test.go
+++ b/module-schema/schema/core_schema_test.go
@@ -28,6 +28,7 @@ variable "name" {
   type        = string
   description = "The name of the resource."
   default     = "default-name"
+  deprecated  = "This variable is deprecated"
 }
 
 variable "tags" {


### PR DESCRIPTION
In Terraform 1.15, new [`deprecated` argument](https://github.com/Azure/ms-terraform-lsp/pull/64) is introduced in `variable` block. However, the argument is not considered in module schema parsing. This causes `update-module-output.yml` workflow to fail with the [error](https://github.com/Azure/ms-terraform-lsp/actions/runs/32009600229/job/95326143800#step:5:6456) below. Particularly, this is due to [`avm-res-avs-privatecloud` module with added `deprecated` argument](https://github.com/Azure/terraform-azurerm-avm-res-avs-privatecloud/blame/5bcbf3bba488dfcb5b3d06a0c081f7680f9f33bb/variables.tf#L885).

```
Error: error processing output: failed to parse HCL file fetched_hcl_files/combinedVar/avm-res-avs-privatecloud_variables.tf: failed to convert HCL body to schema: failed to get block content: fetched_hcl_files/combinedVar/avm-res-avs-privatecloud_variables.tf:892,3-13: Unsupported argument; An argument named "deprecated" is not expected here.
``` 

To fix the issue, `deprecated` argument is added in module schema parsing. All tests pass as shown below. `deprecated` argument is not surfaced in `provider-schema/processors/module_output.json`. If there is a need, another PR can be opened for this purpose.

```
ok      github.com/Azure/ms-terraform-lsp/internal/azure        (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/filesystem   (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/diagnostics       (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers  10.035s
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers/command  2.692s
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers/snippets/azapi   (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers/snippets/msgraph (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers/tfschema 7.292s
ok      github.com/Azure/ms-terraform-lsp/internal/langserver/handlers/validate (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/lsp  (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/mdplain      (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/parser       (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/pathcmp      (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/source       (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/telemetry    (cached)
ok      github.com/Azure/ms-terraform-lsp/internal/uri  (cached)
ok      github.com/Azure/ms-terraform-lsp/module-schema/processor       0.064s
ok      github.com/Azure/ms-terraform-lsp/module-schema/registry        (cached)
ok      github.com/Azure/ms-terraform-lsp/module-schema/schema  0.005s
```